### PR TITLE
Support JSONC Deno configs

### DIFF
--- a/crates/knope-versioning/src/jsonc.rs
+++ b/crates/knope-versioning/src/jsonc.rs
@@ -1,0 +1,82 @@
+/// Utilities for working with JSONC (JSON with comments).
+pub fn strip_json_comments(content: &str) -> String {
+    let mut result = String::new();
+    let mut chars = content.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' if !escaped => {
+                in_string = !in_string;
+                result.push(ch);
+            }
+            '\\' if in_string => {
+                escaped = !escaped;
+                result.push(ch);
+            }
+            '/' if !in_string && !escaped => {
+                if let Some(&next_ch) = chars.peek() {
+                    match next_ch {
+                        '/' => {
+                            chars.next();
+                            while let Some(ch) = chars.next() {
+                                if ch == '\n' {
+                                    result.push(ch);
+                                    break;
+                                }
+                            }
+                        }
+                        '*' => {
+                            chars.next();
+                            while let Some(ch) = chars.next() {
+                                if ch == '*' {
+                                    if let Some(&'/') = chars.peek() {
+                                        chars.next();
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        _ => result.push(ch),
+                    }
+                } else {
+                    result.push(ch);
+                }
+            }
+            _ => {
+                result.push(ch);
+                if ch != '\\' {
+                    escaped = false;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_json_comments;
+
+    #[test]
+    fn removes_line_comments() {
+        let input = "{\n  // comment\n  \"key\": \"value\"\n}";
+        let expected = "{\n  \n  \"key\": \"value\"\n}";
+        assert_eq!(strip_json_comments(input), expected);
+    }
+
+    #[test]
+    fn removes_block_comments() {
+        let input = "{/* comment */\n\"key\": \"value\"\n}";
+        let expected = "{\n\"key\": \"value\"\n}";
+        assert_eq!(strip_json_comments(input), expected);
+    }
+
+    #[test]
+    fn preserves_comments_inside_strings() {
+        let input = "{\n  \"regex\": \"/\\\\/\"\n}";
+        assert_eq!(strip_json_comments(input), input);
+    }
+}

--- a/crates/knope-versioning/src/lib.rs
+++ b/crates/knope-versioning/src/lib.rs
@@ -1,5 +1,6 @@
 mod action;
 pub mod changes;
+pub mod jsonc;
 pub mod package;
 pub mod release_notes;
 pub mod semver;

--- a/crates/knope-versioning/src/package.rs
+++ b/crates/knope-versioning/src/package.rs
@@ -245,7 +245,7 @@ fn validate_dependency(
     versioned_files: &[(Config, &VersionedFile)],
 ) -> Result<Config, Box<NewError>> {
     match (&config.format, config.dependency.is_some()) {
-        (Format::Cargo | Format::PackageJson | Format::PackageLockJson, _)
+        (Format::Cargo | Format::PackageJson | Format::PackageLockJson | Format::DenoJson, _)
         | (Format::CargoLock, true) => Ok(config),
         (Format::CargoLock, false) => {
             // `Cargo.lock` needs to target a dependency. If there is a `Cargo.toml` file which is

--- a/crates/knope-versioning/src/versioned_file/deno_json.rs
+++ b/crates/knope-versioning/src/versioned_file/deno_json.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-use crate::{action::Action, semver::Version};
+use crate::{action::Action, jsonc, semver::Version};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DenoJson {
@@ -24,7 +24,7 @@ impl DenoJson {
             Ok(parsed) => parsed,
             Err(_) => {
                 // If that fails, try to strip comments and parse again (for JSONC)
-                let stripped = Self::strip_json_comments(&content);
+                let stripped = jsonc::strip_json_comments(&content);
                 serde_json::from_str(&stripped).map_err(|err| Error::Deserialize {
                     path: path.clone(),
                     source: err,
@@ -40,69 +40,6 @@ impl DenoJson {
         })
     }
 
-    /// Strip JSON comments (// and /* */) to make JSONC parseable as JSON
-    fn strip_json_comments(content: &str) -> String {
-        let mut result = String::new();
-        let mut chars = content.chars().peekable();
-        let mut in_string = false;
-        let mut escaped = false;
-
-        while let Some(ch) = chars.next() {
-            match ch {
-                '"' if !escaped => {
-                    in_string = !in_string;
-                    result.push(ch);
-                }
-                '\\' if in_string => {
-                    escaped = !escaped;
-                    result.push(ch);
-                }
-                '/' if !in_string && !escaped => {
-                    if let Some(&next_ch) = chars.peek() {
-                        if next_ch == '/' {
-                            // Skip line comment
-                            chars.next(); // consume the second '/'
-                            while let Some(ch) = chars.next() {
-                                if ch == '\n' {
-                                    result.push(ch);
-                                    break;
-                                }
-                            }
-                        } else if next_ch == '*' {
-                            // Skip block comment
-                            chars.next(); // consume the '*'
-                            let mut found_end = false;
-                            while let Some(ch) = chars.next() {
-                                if ch == '*' {
-                                    if let Some(&'/') = chars.peek() {
-                                        chars.next(); // consume the '/'
-                                        found_end = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if !found_end {
-                                // Unclosed comment, but we'll let JSON parser handle the error
-                            }
-                        } else {
-                            result.push(ch);
-                        }
-                    } else {
-                        result.push(ch);
-                    }
-                }
-                _ => {
-                    result.push(ch);
-                    if ch != '\\' {
-                        escaped = false;
-                    }
-                }
-            }
-        }
-
-        result
-    }
-
     pub(crate) fn get_version(&self) -> Option<&Version> {
         self.parsed.version.as_ref()
     }
@@ -116,7 +53,13 @@ impl DenoJson {
         new_version: &Version,
         dependency: Option<&str>,
     ) -> serde_json::Result<Self> {
-        let mut json = serde_json::from_str::<Map<String, Value>>(&self.raw)?;
+        let mut json = match serde_json::from_str::<Map<String, Value>>(&self.raw) {
+            Ok(json) => json,
+            Err(_) => {
+                let stripped = jsonc::strip_json_comments(&self.raw);
+                serde_json::from_str(&stripped)?
+            }
+        };
         let diff = self.diff.get_or_insert_default();
         if !diff.is_empty() {
             diff.push_str(", ");
@@ -220,6 +163,25 @@ mod tests {
         let content = r#"{"name": "@scope/package", "tasks": {"dev": "deno run main.ts"}}"#;
         let deno_json = DenoJson::new("deno.json".into(), content.to_string()).unwrap();
         let new_version = Version::from_str("1.0.0").unwrap();
+        let updated = deno_json.set_version(&new_version, None).unwrap();
+        assert_eq!(updated.get_version(), Some(&new_version));
+    }
+
+    #[test]
+    fn test_deno_json_with_comments() {
+        let content = "// leading comment\n{\"name\": \"@scope/package\", \"version\": \"1.0.0\"}";
+        let deno_json = DenoJson::new("deno.jsonc".into(), content.to_string()).unwrap();
+        assert_eq!(
+            deno_json.get_version(),
+            Some(&Version::from_str("1.0.0").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_set_version_with_comment_source() {
+        let content = "// leading comment\n{\"name\": \"@scope/package\", \"version\": \"1.0.0\"}";
+        let deno_json = DenoJson::new("deno.jsonc".into(), content.to_string()).unwrap();
+        let new_version = Version::from_str("1.2.0").unwrap();
         let updated = deno_json.set_version(&new_version, None).unwrap();
         assert_eq!(updated.get_version(), Some(&new_version));
     }

--- a/crates/knope/src/config/package.rs
+++ b/crates/knope/src/config/package.rs
@@ -4,7 +4,7 @@ use ::toml::Spanned;
 use glob::glob;
 use itertools::Itertools;
 use knope_config::{Assets, ChangelogSection};
-use knope_versioning::{UnknownFile, VersionedFileConfig, package, versioned_file::cargo};
+use knope_versioning::{UnknownFile, VersionedFileConfig, jsonc, package, versioned_file::cargo};
 use miette::Diagnostic;
 use relative_path::{PathExt, RelativePath, RelativePathBuf};
 use serde_json::Value;
@@ -262,11 +262,16 @@ impl Package {
             })
         })?;
 
-        let json =
-            serde_json::Value::from_str(&contents).map_err(|err| DenoWorkspaceError::Json {
-                path: relative_path.clone(),
-                source: err,
-            })?;
+        let json = match serde_json::Value::from_str(&contents) {
+            Ok(json) => json,
+            Err(_) => {
+                let stripped = jsonc::strip_json_comments(&contents);
+                serde_json::Value::from_str(&stripped).map_err(|err| DenoWorkspaceError::Json {
+                    path: relative_path.clone(),
+                    source: err,
+                })?
+            }
+        };
 
         Ok(Some((relative_path, json)))
     }
@@ -285,69 +290,6 @@ impl Package {
         }
 
         Ok(None)
-    }
-
-    /// Strip JSON comments (// and /* */) to make JSONC parseable as JSON
-    fn strip_json_comments(content: &str) -> String {
-        let mut result = String::new();
-        let mut chars = content.chars().peekable();
-        let mut in_string = false;
-        let mut escaped = false;
-
-        while let Some(ch) = chars.next() {
-            match ch {
-                '"' if !escaped => {
-                    in_string = !in_string;
-                    result.push(ch);
-                }
-                '\\' if in_string => {
-                    escaped = !escaped;
-                    result.push(ch);
-                }
-                '/' if !in_string && !escaped => {
-                    if let Some(&next_ch) = chars.peek() {
-                        if next_ch == '/' {
-                            // Skip line comment
-                            chars.next(); // consume the second '/'
-                            while let Some(ch) = chars.next() {
-                                if ch == '\n' {
-                                    result.push(ch);
-                                    break;
-                                }
-                            }
-                        } else if next_ch == '*' {
-                            // Skip block comment
-                            chars.next(); // consume the '*'
-                            let mut found_end = false;
-                            while let Some(ch) = chars.next() {
-                                if ch == '*' {
-                                    if let Some(&'/') = chars.peek() {
-                                        chars.next(); // consume the '/'
-                                        found_end = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if !found_end {
-                                // Unclosed comment, but we'll let JSON parser handle the error
-                            }
-                        } else {
-                            result.push(ch);
-                        }
-                    } else {
-                        result.push(ch);
-                    }
-                }
-                _ => {
-                    result.push(ch);
-                    if ch != '\\' {
-                        escaped = false;
-                    }
-                }
-            }
-        }
-
-        result
     }
 
     fn deno_workspaces() -> Result<Vec<Self>, DenoWorkspaceError> {
@@ -370,7 +312,7 @@ impl Package {
             Ok(json) => json,
             Err(_) => {
                 // Try to strip comments and parse again (for JSONC)
-                let stripped = Self::strip_json_comments(&root_deno_content);
+                let stripped = jsonc::strip_json_comments(&root_deno_content);
                 serde_json::Value::from_str(&stripped)
                     .ok()
                     .unwrap_or_default()
@@ -636,4 +578,39 @@ pub(crate) enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     DenoWorkspace(#[from] DenoWorkspaceError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::tempdir_in;
+
+    use super::Package;
+
+    #[test]
+    fn try_read_deno_config_file_supports_jsonc() {
+        let temp_dir = tempdir_in(".").unwrap();
+        let file_path = temp_dir.path().join("deno.jsonc");
+        fs::write(
+            &file_path,
+            "{\n  // comment\n  \"name\": \"@scope/package\",\n  \"version\": \"1.0.0\"\n}\n",
+        )
+        .unwrap();
+
+        let relative_path = file_path
+            .strip_prefix(std::env::current_dir().unwrap())
+            .unwrap()
+            .to_path_buf();
+
+        let result = Package::try_read_deno_config_file(relative_path).unwrap();
+        let (path, json) = result.expect("file should parse");
+
+        assert!(path.as_str().ends_with("deno.jsonc"));
+        assert_eq!(
+            json.get("name"),
+            Some(&Value::String("@scope/package".into()))
+        );
+    }
 }

--- a/crates/knope/tests/prepare_release/deno/workspaces/out/second/deno.json
+++ b/crates/knope/tests/prepare_release/deno/workspaces/out/second/deno.json
@@ -3,6 +3,6 @@
   "version": "0.1.1",
   "exports": "./mod.ts",
   "imports": {
-    "@scope/first-package": "jsr:@scope/first-package@^1.0.0"
+    "@scope/first-package": "jsr:@scope/first-package@^1.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- share a reusable JSONC comment stripping helper and add focused unit tests
- Parse JSONC inputs and permit dependency rewrites in deno workspaces
- update the deno workspace snapshot to validate dependency ranges are bumped

## Testing
- cargo test -p knope-versioning
- cargo test -p knope

